### PR TITLE
feat(convex-vite-plugin): expose admin key from ConvexBackend

### DIFF
--- a/.changeset/expose-admin-key.md
+++ b/.changeset/expose-admin-key.md
@@ -1,0 +1,5 @@
+---
+"convex-vite-plugin": minor
+---
+
+Add `getAdminKey()` method to `ConvexBackend` class for creating custom authenticated clients

--- a/packages/convex-vite-plugin/src/backend.ts
+++ b/packages/convex-vite-plugin/src/backend.ts
@@ -97,6 +97,14 @@ export class ConvexBackend {
   }
 
   /**
+   * Get the admin key for authenticating with the Convex backend.
+   * Use this to create your own ConvexClient with admin privileges.
+   */
+  public getAdminKey(): string {
+    return this.adminKey;
+  }
+
+  /**
    * Spawn the backend process.
    * Returns immediately after spawning - does not wait for the backend to be ready.
    * Call waitForReady() to ensure the backend is accepting connections.


### PR DESCRIPTION
## Summary
- Add `getAdminKey()` method to `ConvexBackend` class
- Allows users to create their own authenticated Convex clients with admin privileges

## Test plan
- [x] Build passes
- [x] Method is exported in generated types

🤖 Generated with [Claude Code](https://claude.com/claude-code)