### PR TITLE
fix: remove trailing whitespace in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # agent-tools
 
-I made some tools to improve the agentic development for my current stack. Decided to publish some of them, idk if they're useful to anyone else. 
+I made some tools to improve the agentic development for my current stack. Decided to publish some of them, idk if they're useful to anyone else.
 
 Use on your own risk. Assume everything in this repo is fully vibe coded.
 


### PR DESCRIPTION
Removes trailing whitespace from line 3 of the README for cleaner formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)