### PR TITLE
Disable seeding by default in example app

### DIFF
--- a/examples/convex-spa/vite.config.ts
+++ b/examples/convex-spa/vite.config.ts
@@ -11,7 +11,8 @@ export default defineConfig({
       envVars: (vitePort) => ({
         SITE_URL: `http://localhost:${vitePort}`,
       }),
-      onReady: [{ name: "functions:seed" }],
+      // Seed on startup
+      // onReady: [{ name: "functions:seed" }],
     }),
   ],
 });


### PR DESCRIPTION
Disable the seed function from running on backend startup in the example app, allowing developers to start with a clean slate.

This change makes the example more suitable for exploration and testing without requiring a data reset between runs.