### PR TITLE
refactor: remove bun dependency from convex-vite-plugin

### DIFF
--- a/.changeset/yywtmzd5.md
+++ b/.changeset/yywtmzd5.md
@@ -1,0 +1,5 @@
+---
+"convex-vite-plugin": patch
+---
+
+Remove hardcoded bun dependency from plugin. The plugin now detects the package manager (npm, yarn, pnpm, or bun) from the `npm_config_user_agent` environment variable and uses the appropriate exec command (npx, yarn exec, pnpm exec, or bunx).

--- a/packages/convex-vite-plugin/src/backend.ts
+++ b/packages/convex-vite-plugin/src/backend.ts
@@ -10,7 +10,12 @@ import type { ConvexLogger, LogLevel } from "./logger.ts";
 
 import { generateKeyPair } from "./keys.ts";
 import { normalizeLogger } from "./logger.ts";
-import { downloadConvexBinary, waitForHttpOk } from "./utils.ts";
+import {
+  detectPackageManager,
+  downloadConvexBinary,
+  getExecCommand,
+  waitForHttpOk,
+} from "./utils.ts";
 
 /**
  * Options for creating a ConvexBackend instance.
@@ -222,9 +227,12 @@ export class ConvexBackend {
 
     const backendUrl = `http://localhost:${this.port}`;
 
+    const pm = detectPackageManager();
+    const { cmd, args } = getExecCommand(pm);
+
     const deployResult = childProcess.spawnSync(
-      "bun",
-      ["convex", "deploy", "--admin-key", this.adminKey, "--url", backendUrl],
+      cmd,
+      [...args, "convex", "deploy", "--admin-key", this.adminKey, "--url", backendUrl],
       {
         cwd: this.projectDir,
         encoding: "utf-8",


### PR DESCRIPTION
Remove hardcoded bun dependency from the plugin. The plugin now detects the package manager (npm, yarn, pnpm, or bun) from the `npm_config_user_agent` environment variable and uses the appropriate exec command instead.

Works with all package managers out of the box.