### PR TITLE
fix(oxlint-plugin-convex): scan .svelte and .vue files for api.* usage

### DIFF
--- a/packages/oxlint-plugin-convex/src/index.ts
+++ b/packages/oxlint-plugin-convex/src/index.ts
@@ -86,7 +86,7 @@ export type RuleOptions = {
 /**
  * Get all project files with the given extensions, excluding common directories.
  */
-const DEFAULT_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx"];
+const DEFAULT_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx", ".svelte", ".vue"];
 const DEFAULT_SKIP_DIRS = [
   "node_modules",
   ".git",


### PR DESCRIPTION
Fixes #22

Adds `.svelte` and `.vue` to `DEFAULT_EXTENSIONS` so the usage scanner picks up `api.x.y` / `internal.x.y` references in SvelteKit and Nuxt projects.

One-line change. Tested locally by patching `dist/index.mjs` in a SvelteKit + Convex project. Correctly eliminated 3 false positives (functions only referenced in `.svelte` components).