### PR TITLE
fix(convex-vite-plugin): Redact env var values in startup logs

### DIFF
--- a/packages/convex-vite-plugin/src/index.ts
+++ b/packages/convex-vite-plugin/src/index.ts
@@ -382,7 +382,11 @@ export function convexLocal(options: ConvexLocalOptions = {}): Plugin {
 
               for (const [name, value] of Object.entries(envVars)) {
                 await backend.setEnv(name, value);
-                logger.info(`Set environment variable: ${name} = ${value}`, { timestamp: true });
+                const masked =
+                  value.length > 4
+                    ? value.slice(0, 2) + "·".repeat(Math.min(value.length - 2, 5))
+                    : "····";
+                logger.info(`Set environment variable: ${name} = ${masked}`, { timestamp: true });
               }
             }
 


### PR DESCRIPTION
Mask sensitive environment variable values when logging during local dev startup. Shows only first 2 characters to aid debugging while keeping secrets out of terminal history and screen shares.

Resolves #24